### PR TITLE
ST-2192: Rename with-ours to skip-commits

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ def find_files(path):
 
 setuptools.setup(
     name='workspace-tools',
-    version='3.3.11',
+    version='3.3.12',
 
     author='Max Zheng',
     author_email='maxzheng.os@gmail.com',

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -71,7 +71,7 @@ def test_merge_branch_with_whitelist(wst, capsys):
 
         run('git checkout master')
 
-        wst('merge 3.0.x --with-ours \'skip\' \'space separated example\'')
+        wst('merge 3.0.x --skip-commits \'skip\' \'space separated example\'')
 
         changes = run('git log --oneline', return_output=True)
         # Change should have been in the log entry


### PR DESCRIPTION
We had some confusion/concerns around the `with-ours` option and hence decided to rename the option to `skip-commits` which is more explicit. 


Note: We have a backlog item (ST-2242) to get rid of the workspace-tools repo and
move the logic to the release-tools.