### PR TITLE
ST-2637: Edited merge_branch() to create a commit message when calling git merge with a strategy

### DIFF
--- a/workspace/scm.py
+++ b/workspace/scm.py
@@ -193,6 +193,10 @@ def merge_branch(branch, commit=None, squash=False, strategy=None):
         cmd.append('--squash')
     if strategy:
         cmd.append('--strategy=' + strategy)
+        if commit is None:
+            current = current_branch()
+            message = f"Merge branch {branch} into {current} (using strategy {strategy})"
+            cmd.append('-m ' + message)
     if commit:
         cmd.append(commit)
     silent_run(cmd)


### PR DESCRIPTION
Edited the merge_branch() method in scm.py. Created a message using current_branch() method and branch argument to recreate the default message, and added strategy to message, when not doing individual commits. Added message into the merge command being run. Tested locally by simulating the message being run.